### PR TITLE
chore(deps): improve dependencies constraints for compatibility

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,7 @@
 analyzer:
   errors:
     avoid_function_literals_in_foreach_calls: ignore
+    unintended_html_in_doc_comment: ignore
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/lib/flutter_quill_delta_from_html.dart
+++ b/lib/flutter_quill_delta_from_html.dart
@@ -1,4 +1,5 @@
-library flutter_quill_delta_from_html;
+/// Convert HTML content to [Quill Delta](https://quilljs.com/docs/delta) format.
+library;
 
 export 'package:flutter_quill_delta_from_html/parser/font_size_parser.dart';
 export 'package:flutter_quill_delta_from_html/parser/indent_parser.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,17 +6,13 @@ repository: https://github.com/CatHood0/flutter_quill_delta_from_html
 issue_tracker: https://github.com/CatHood0/flutter_quill_delta_from_html/issues
 
 environment:
-  sdk: ">=3.4.3 <4.0.0"
-  flutter: ">=1.17.0"
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  dart_quill_delta: ^10.6.0
-  html: ^0.15.4
+  dart_quill_delta: ^10.0.0
+  html: ^0.15.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0
-
-flutter:
-  uses-material-design: true
+  flutter_lints: ^5.0.0


### PR DESCRIPTION
The versions listed in `pubspec.yaml` indicate the minimum required for dependencies 
and do not affect those used in the client's application.
For more information, visit:

* https://dart.dev/tools/pub/dependencies#version-constraints
* https://docs.flutter.dev/packages-and-plugins/using-packages#conflict-resolution
* https://dart.dev/tools/pub/versioning
* https://dart.dev/guides/libraries/private-files#pubspec-lock
* https://dart.dev/tools/pub/pubspec#sdk-constraints

The `pubspec.lock` should be included only for application packages, which contain the used dependencies versions.
When the client runs `flutter pub get` they will get the latest compatible dependencies at the time until they run `flutter pub upgrade`. The `flutter pub upgrade --major-versions` updates the major versions in `pubspec.yaml`.

### Changes

* Updates the package to not require Flutter SDK or Google material icons
* Updates flutter_lints to 5.0.0 and fix analysis warnings
* Updates minimum supported Dart SDK version From 3.4.3 to 3.0

### Aditional Context

There is an analysis warning coming from [`unintended_html_in_doc_comment`](https://dart.dev/tools/linter-rules/unintended_html_in_doc_comment) which will be enabled by default and part of the [core set starting from `5.1.0`](https://github.com/dart-lang/core/issues/826). I ignored the warning to avoid additional changes.

This repo will probably need an `example` so contributors and CI can test against the latest dependencies (`pubspec.lock` included).

This PR fixes an issue on the Flutter Quill repo:

- https://github.com/singerdmx/flutter-quill/issues/2347

<details><summary>Details</summary>
<p>

```console
Resolving dependencies...
The current Dart SDK version is 3.3.3.

Because flutter_quill >=10.6.1 depends on flutter_quill_delta_from_html >=1.1.5 which requires SDK version >=3.4.3 <4.0.0, flutter_quill >=10.6.1 is forbidden.
So, because su depends on flutter_quill 10.8.5, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on flutter_quill: flutter pub add flutter_quill:^2.0.7
exit code 1

```

</p>
</details> 