### PR TITLE
Added exception handling to color parsing

### DIFF
--- a/lib/parser/colors.dart
+++ b/lib/parser/colors.dart
@@ -19,7 +19,11 @@
 String? validateAndGetColor(String colorString) {
   //verify if the color already is a hex
   if (colorString.startsWith('#')) return colorString;
-  return colorToHex(colorString);
+  try {
+    return colorToHex(colorString);
+  } catch (_) {
+    return null;
+  }
 }
 
 /// Decides the color format type and converts it to hexadecimal format.


### PR DESCRIPTION
Added exception handling when parsing a color value.  Saw the following css color value on a website...

color: rgb(0 0 0/var(--tw-text-opacity));

Looks like something from Tailwind CSS.  In any case, released code throws an exception and clipboard paste is halted.