### PR TITLE
Fix: paragraph wrong breaks and weird trim() of some text elements

### DIFF
--- a/lib/parser/extensions/node_ext.dart
+++ b/lib/parser/extensions/node_ext.dart
@@ -28,6 +28,17 @@ extension NodeExt on Element {
 
   ///Ensure to detect span html tags
   bool get isSpan => localName == 'span';
+  bool get isBlock =>
+      isList || isHeader || isDivBlock || isBlockquote || isCodeBlock;
+  bool get isInline =>
+      isSpan ||
+      isParagraph ||
+      isLink ||
+      isStrong ||
+      isStrike ||
+      isItalic ||
+      isUnderline ||
+      isSubscript;
 
   ///Ensure to detect h(1-6) html tags
   bool get isHeader =>

--- a/lib/parser/extensions/string_ext.dart
+++ b/lib/parser/extensions/string_ext.dart
@@ -1,0 +1,4 @@
+extension StringExt on String {
+  String get transformNewLinesToBrTag => replaceAll('\n', '<br>');
+  String get removeAllNewLines => replaceAll('\n', '');
+}


### PR DESCRIPTION
# Description

First, a problem was fixed where some nodes do not split if the next one is considered a block (Quill) which means you have to split them to avoid unexpected behavior.

Finally, a problem was fixed where some nodes directly remove the spaces they have to their left and right when it is not necessary or they should not.

> [!NOTE]
> `trimText` was deprecated because its function was replaced with the previous solution which is already enabled by default and there is no way to remove it.

# Issues related

[Spaces outside the tag on both sides are lost #10](https://github.com/CatHood0/flutter_quill_delta_from_html/issues/10)
[Paragraph text gets added to list item #14](https://github.com/CatHood0/flutter_quill_delta_from_html/issues/14)
