### PR TITLE
Handle table tags / handle line-height exceptions (i.e. inherit)

### DIFF
--- a/lib/parser/default_html_to_ops.dart
+++ b/lib/parser/default_html_to_ops.dart
@@ -242,8 +242,7 @@ class DefaultHtmlToOperations extends HtmlOperations {
   List<Operation> imgToOp(dom.Element element) {
     final String src = element.getSafeAttribute('src');
     final String styles = element.getSafeAttribute('style');
-    final attributes =
-        parseImageStyleAttribute(styles, element.getSafeAttribute('align'));
+    final attributes = parseImageStyleAttribute(styles, element.getSafeAttribute('align'));
     if (src.isNotEmpty) {
       return [
         Operation.insert(
@@ -309,5 +308,23 @@ class DefaultHtmlToOperations extends HtmlOperations {
   @override
   List<Operation> brToOp(dom.Element element) {
     return [Operation.insert('\n')];
+  }
+
+  @override
+  List<Operation> tableToOp(dom.Element element) {
+    final List<Operation> ops = [];
+
+    for (final node in element.nodes) {
+      if (node.nodeType == dom.Node.ELEMENT_NODE) {
+        final element = node as dom.Element;
+        if (element.localName == 'td') {
+          ops.addAll(paragraphToOp(element));
+        } else {
+          ops.addAll(divToOp(element));
+        }
+      }
+    }
+
+    return ops;
   }
 }

--- a/lib/parser/extensions/node_ext.dart
+++ b/lib/parser/extensions/node_ext.dart
@@ -69,6 +69,9 @@ extension NodeExt on Element {
   ///Ensure to detect div html tags
   bool get isDivBlock => localName == 'div';
 
+  ///Ensure to detect table html tags
+  bool get isTable => ['table', 'tbody', 'thead', 'tfoot', 'tr', 'td'].contains(localName);
+
   String getSafeAttribute(String attr) {
     return attributes[attr] ?? '';
   }

--- a/lib/parser/html_to_delta.dart
+++ b/lib/parser/html_to_delta.dart
@@ -153,13 +153,15 @@ class HtmlToDelta {
       }
     }
     //ensure insert a new line at the final to avoid any conflict with assertions
-    final Operation lastOpdata = delta.last;
-    final bool lastDataIsNotNewLine = lastOpdata.data.toString() != '\n';
-    final bool hasAttributes = lastOpdata.attributes != null;
-    if (lastDataIsNotNewLine && hasAttributes ||
-        lastDataIsNotNewLine ||
-        !lastDataIsNotNewLine && hasAttributes) {
-      delta.insert('\n');
+    if (delta.isNotEmpty) {
+      final Operation lastOpdata = delta.last;
+      final bool lastDataIsNotNewLine = lastOpdata.data.toString() != '\n';
+      final bool hasAttributes = lastOpdata.attributes != null;
+      if (lastDataIsNotNewLine && hasAttributes ||
+          lastDataIsNotNewLine ||
+          !lastDataIsNotNewLine && hasAttributes) {
+        delta.insert('\n');
+      }
     }
     return delta;
   }

--- a/lib/parser/html_to_operation.dart
+++ b/lib/parser/html_to_operation.dart
@@ -58,6 +58,7 @@ abstract class HtmlOperations {
     if (element.isBlockquote) ops.addAll(blockquoteToOp(element));
     if (element.isCodeBlock) ops.addAll(codeblockToOp(element));
     if (element.isDivBlock) ops.addAll(divToOp(element));
+    if (element.isTable) ops.addAll(tableToOp(element));
     return ops;
   }
 
@@ -93,6 +94,9 @@ abstract class HtmlOperations {
 
   /// Converts a div HTML element (`<div>`) to Delta operations.
   List<Operation> divToOp(dom.Element element);
+
+  /// Converts a table HTML element (`<table>`) to Delta operations.
+  List<Operation> tableToOp(dom.Element element);
 
   /// Sets custom HTML parts to extend the conversion capabilities.
   ///

--- a/lib/parser/html_utils.dart
+++ b/lib/parser/html_utils.dart
@@ -102,8 +102,12 @@ Map<String, dynamic> parseStyleAttribute(String style) {
           attributes['font'] = value;
           break;
         case 'line-height':
-          final lineHeight = parseLineHeight(value, fontSize: fontSize ?? 16.0);
-          attributes['line-height'] = lineHeight;
+          try {
+            final lineHeight = parseLineHeight(value, fontSize: fontSize ?? 16.0);
+            attributes['line-height'] = lineHeight;
+          } catch (e) {
+            //ignore error (i.e. 'line-height: inherit;')
+          }
           break;
         default:
           break;


### PR DESCRIPTION
1) if there was a conversation error and no operations were in the delta, fixed an exception when checking delta.last

2) html table/tbody/thead/tfoot/tr are now handled in a manner similar to divs.  html td is now handled similar to paragraph. i.e. table td cells are pasted as paragraphs

3) line-height: inherit was throwing an exception and is now ignored