### PR TITLE
Refactor: Safely access 'last' element in operations

### DIFF
--- a/lib/parser/html_to_delta.dart
+++ b/lib/parser/html_to_delta.dart
@@ -106,23 +106,18 @@ class HtmlToDelta {
         .join()
         .removeAllNewLines;
     final Delta delta = Delta();
-    final dom.Document $document = dparser.parse(replaceNormalNewLinesToBr
-        ? parsedText.transformNewLinesToBrTag
-        : parsedText);
+    final dom.Document $document = dparser.parse(replaceNormalNewLinesToBr ? parsedText.transformNewLinesToBrTag : parsedText);
     final dom.Element? $body = $document.body;
     final dom.Element? $html = $document.documentElement;
 
     // Determine nodes to process: <body>, <html>, or document nodes if neither is present
-    final List<dom.Node> nodesToProcess =
-        $body?.nodes ?? $html?.nodes ?? $document.nodes;
+    final List<dom.Node> nodesToProcess = $body?.nodes ?? $html?.nodes ?? $document.nodes;
 
     for (int i = 0; i < nodesToProcess.length; i++) {
       dom.Node node = nodesToProcess[i];
       //first just verify if the customBlocks aren't empty and then store on them to
       //validate if one of them make match with the current Node
-      if (customBlocks != null &&
-          customBlocks!.isNotEmpty &&
-          node is dom.Element) {
+      if (customBlocks != null && customBlocks!.isNotEmpty && node is dom.Element) {
         for (CustomHtmlPart customBlock in customBlocks!) {
           if (customBlock.matches(node)) {
             final operations = customBlock.convert(node);
@@ -137,10 +132,7 @@ class HtmlToDelta {
 
       bool nextIsBlock = nextNode is dom.Element ? nextNode.isBlock : false;
       if (isBlockValidator != null) {
-        nextIsBlock = isBlockValidator?.call(nextNode is dom.Element
-                ? nextNode.localName ?? 'no-localname'
-                : 'text-node') ??
-            false;
+        nextIsBlock = isBlockValidator?.call(nextNode is dom.Element ? nextNode.localName ?? 'no-localname' : 'text-node') ?? false;
       }
 
       final List<Operation> operations = nodeToOperation(
@@ -155,8 +147,7 @@ class HtmlToDelta {
           delta.insert(op.data, op.attributes);
         }
       }
-      final bool? shouldInsertNewLine = shouldInsertANewLine?.call(
-          node is dom.Element ? node.localName ?? 'no-localname' : 'text-node');
+      final bool? shouldInsertNewLine = shouldInsertANewLine?.call(node is dom.Element ? node.localName ?? 'no-localname' : 'text-node');
       if (shouldInsertNewLine != null && shouldInsertNewLine) {
         delta.insert('\n');
       }
@@ -166,9 +157,7 @@ class HtmlToDelta {
       final Operation lastOpdata = delta.last;
       final bool lastDataIsNotNewLine = lastOpdata.data.toString() != '\n';
       final bool hasAttributes = lastOpdata.attributes != null;
-      if (lastDataIsNotNewLine && hasAttributes ||
-          lastDataIsNotNewLine ||
-          !lastDataIsNotNewLine && hasAttributes) {
+      if (lastDataIsNotNewLine && hasAttributes || lastDataIsNotNewLine || !lastDataIsNotNewLine && hasAttributes) {
         delta.insert('\n');
       }
     }
@@ -201,14 +190,11 @@ class HtmlToDelta {
     final dom.Element? $html = $document.documentElement;
 
     // Determine nodes to process: <body>, <html>, or document nodes if neither is present
-    final List<dom.Node> nodesToProcess =
-        $body?.nodes ?? $html?.nodes ?? $document.nodes;
+    final List<dom.Node> nodesToProcess = $body?.nodes ?? $html?.nodes ?? $document.nodes;
 
     for (int i = 0; i < nodesToProcess.length; i++) {
       dom.Node node = nodesToProcess[i];
-      if (customBlocks != null &&
-          customBlocks!.isNotEmpty &&
-          node is dom.Element) {
+      if (customBlocks != null && customBlocks!.isNotEmpty && node is dom.Element) {
         for (var customBlock in customBlocks!) {
           if (customBlock.matches(node)) {
             final operations = customBlock.convert(node);
@@ -226,10 +212,7 @@ class HtmlToDelta {
               ? false
               : nextNode.isBlock;
       if (isBlockValidator != null) {
-        nextIsBlock = isBlockValidator?.call(nextNode is dom.Element
-                ? nextNode.localName ?? 'no-localname'
-                : 'text-node') ??
-            false;
+        nextIsBlock = isBlockValidator?.call(nextNode is dom.Element ? nextNode.localName ?? 'no-localname' : 'text-node') ?? false;
       }
       final List<Operation> operations = nodeToOperation(
         node,
@@ -242,8 +225,7 @@ class HtmlToDelta {
           delta.insert(op.data, op.attributes);
         }
       }
-      final bool? shouldInsertNewLine = shouldInsertANewLine?.call(
-          node is dom.Element ? node.localName ?? 'no-localname' : 'text-node');
+      final bool? shouldInsertNewLine = shouldInsertANewLine?.call(node is dom.Element ? node.localName ?? 'no-localname' : 'text-node');
       if (shouldInsertNewLine != null && shouldInsertNewLine) {
         delta.insert('\n');
       }
@@ -252,9 +234,7 @@ class HtmlToDelta {
     final Operation lastOpdata = delta.last;
     final bool lastDataIsNotNewLine = lastOpdata.data.toString() != '\n';
     final bool hasAttributes = lastOpdata.attributes != null;
-    if (lastDataIsNotNewLine && hasAttributes ||
-        lastDataIsNotNewLine ||
-        !lastDataIsNotNewLine && hasAttributes) {
+    if (lastDataIsNotNewLine && hasAttributes || lastDataIsNotNewLine || !lastDataIsNotNewLine && hasAttributes) {
       delta.insert('\n');
     }
     return delta;
@@ -301,7 +281,7 @@ class HtmlToDelta {
       // Check if the nextElement is a block AND if the last
       // operation already has a new line, this would otherwise
       // create a double new line
-      if (nextIsBlock && operations.last.data != '\n') {
+      if (nextIsBlock && operations.lastOrNull?.data != '\n') {
         operations.add(Operation.insert('\n'));
       }
     }


### PR DESCRIPTION
The previous code directly accessed `operations.last`, which could lead to a `NoSuchElementException` if the `operations` list was empty.

This commit changes the access to `operations.lastOrNull?.data`, which safely returns `null` if the list is empty, preventing potential runtime errors.
